### PR TITLE
Take radio-button label text from semantics.json

### DIFF
--- a/radio-selector.js
+++ b/radio-selector.js
@@ -119,7 +119,7 @@ H5PEditor.widgets.radioSelector = H5PEditor.RadioSelector = (function ($, EventD
     var createRadioButtons = function () {
       $values.children().each(function (idx) {
         var show = '';
-        var label = $(this).find('.h5peditor-label').eq(0).html();
+        var label = field.fields[idx].label;
 
         // Show current option
         if (idx === currentOption) {


### PR DESCRIPTION
Per explanation in Issue #1, the Radio Selector is not using the "label" value from semantics.json for the radio button text . It takes the text from the rendered HTML. This is a problem with the _group_  semantic type. The _group_ semantic type uses a different class name for its label, so the incorrect value is used. It also appends additional text the the label. Even if the label text was correctly fetched, it would be inappropriate for the radio button text. Further details at https://h5p.org/node/37027